### PR TITLE
[update] Add field(fullnode,bootnod) return from debugapi/health.

### DIFF
--- a/openapi/Aurora.yaml
+++ b/openapi/Aurora.yaml
@@ -10,7 +10,7 @@ security:
 
 externalDocs:
   description: Browse the documentation @ the aurorafs Docs
-  url: "https://docs.boson.eth"
+  url: ""
 
 servers:
   - url: "http://{apiRoot}:{port}/v1"

--- a/openapi/AuroraCommon.yaml
+++ b/openapi/AuroraCommon.yaml
@@ -169,6 +169,17 @@ components:
         status:
           type: string
 
+    HealthStatus:
+      type: object
+      properties:
+        status:
+          type: string
+        version:
+          type: string
+        fullnode:
+          type: boolean
+        bootnodemode:
+          type: boolean
 
     AuroraAddress:
       type: string

--- a/openapi/AuroraDebug.yaml
+++ b/openapi/AuroraDebug.yaml
@@ -34,7 +34,22 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "AuroraCommon.yaml#/components/schemas/Status"
+                $ref: "AuroraCommon.yaml#/components/schemas/HealthStatus"
+        default:
+          description: Default response
+
+  "/health":
+    get:
+      summary: Get health of node
+      tags:
+        - Status
+      responses:
+        "200":
+          description: Health State of node
+          content:
+            application/json:
+              schema:
+                $ref: "AuroraCommon.yaml#/components/schemas/HealthStatus"
         default:
           description: Default response
 
@@ -237,20 +252,7 @@ paths:
         default:
           description: Default response
 
-  "/health":
-    get:
-      summary: Get health of node
-      tags:
-        - Status
-      responses:
-        "200":
-          description: Health State of node
-          content:
-            application/json:
-              schema:
-                $ref: "AuroraCommon.yaml#/components/schemas/Status"
-        default:
-          description: Default response
+
 
 
   "/metrics":

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -45,15 +45,28 @@ type Service struct {
 	corsAllowedOrigins []string
 	metricsRegistry    *prometheus.Registry
 	// handler is changed in the Configure method
-	handler   http.Handler
-	handlerMu sync.RWMutex
+	handler     http.Handler
+	handlerMu   sync.RWMutex
+	nodeOptions Options
+}
+
+type Options struct {
+	PrivateKey     *ecdsa.PrivateKey
+	NATAddr        string
+	EnableWS       bool
+	EnableQUIC     bool
+	FullNode       bool
+	BootNodeMode   bool
+	LightNodeLimit int
+	WelcomeMessage string
+	Transaction    []byte
 }
 
 // New creates a new Debug API Service with only basic routers enabled in order
 // to expose /addresses, /health endpoints, Go metrics and pprof. It is useful to expose
 // these endpoints before all dependencies are configured and injected to have
 // access to basic debugging tools and /health endpoint.
-func New(overlay boson.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, logger logging.Logger, tracer *tracing.Tracer, corsAllowedOrigins []string) *Service {
+func New(overlay boson.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, logger logging.Logger, tracer *tracing.Tracer, corsAllowedOrigins []string, o Options) *Service {
 	s := new(Service)
 	s.overlay = overlay
 	s.publicKey = publicKey
@@ -63,7 +76,7 @@ func New(overlay boson.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereu
 	s.tracer = tracer
 	s.corsAllowedOrigins = corsAllowedOrigins
 	s.metricsRegistry = newMetricsRegistry()
-
+	s.nodeOptions = o
 	s.setRouter(s.newBasicRouter())
 
 	return s

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -46,11 +46,6 @@ func (s *Service) newBasicRouter() *mux.Router {
 
 	router.Handle("/debug/vars", expvar.Handler())
 
-	router.Handle("/health", web.ChainHandlers(
-		httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
-		web.FinalHandlerFunc(statusHandler),
-	))
-
 	router.Handle("/addresses", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.addressesHandler),
 	})
@@ -64,10 +59,9 @@ func (s *Service) newBasicRouter() *mux.Router {
 func (s *Service) newRouter() *mux.Router {
 	router := s.newBasicRouter()
 
-	router.Handle("/readiness", web.ChainHandlers(
-		httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
-		web.FinalHandlerFunc(statusHandler),
-	))
+	router.Handle("/readiness", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.statusHandler),
+	})
 
 	router.Handle("/pingpong/{peer-id}", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.pingpongHandler),
@@ -108,6 +102,15 @@ func (s *Service) newRouter() *mux.Router {
 	router.Handle("/chunk/server/{rootCid}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.chunkInfoServerHandler),
 	})
+
+	router.Handle("/chunk/server/{rootCid}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.chunkInfoServerHandler),
+	})
+
+	router.Handle("/health", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.statusHandler),
+	})
+
 	//router.Handle("/balances", jsonhttp.MethodHandler{
 	//	"GET": http.HandlerFunc(s.compensatedBalancesHandler),
 	//})

--- a/pkg/debugapi/status.go
+++ b/pkg/debugapi/status.go
@@ -8,13 +8,17 @@ import (
 )
 
 type statusResponse struct {
-	Status  string `json:"status"`
-	Version string `json:"version"`
+	Status       string `json:"status"`
+	Version      string `json:"version"`
+	FullNode     bool   `json:"fullnode"`
+	BootNodeMode bool   `json:"bootnodemode"`
 }
 
-func statusHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) statusHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, statusResponse{
-		Status:  "ok",
-		Version: aufs.Version,
+		Status:       "ok",
+		Version:      aufs.Version,
+		FullNode:     s.nodeOptions.FullNode,
+		BootNodeMode: s.nodeOptions.BootNodeMode,
 	})
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -133,7 +133,16 @@ func NewAurora(addr string, bosonAddress boson.Address, publicKey ecdsa.PublicKe
 			return nil, fmt.Errorf("eth address: %w", err)
 		}
 		// set up basic debug api endpoints for debugging and /health endpoint
-		debugAPIService = debugapi.New(bosonAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, logger, tracer, o.CORSAllowedOrigins)
+		debugAPIService = debugapi.New(bosonAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, logger, tracer, o.CORSAllowedOrigins, debugapi.Options{
+			PrivateKey:     libp2pPrivateKey,
+			NATAddr:        o.NATAddr,
+			EnableWS:       o.EnableWS,
+			EnableQUIC:     o.EnableQUIC,
+			FullNode:       o.FullNode,
+			BootNodeMode:   o.BootnodeMode,
+			WelcomeMessage: o.WelcomeMessage,
+			LightNodeLimit: o.LightNodeMaxPeers,
+		})
 
 		debugAPIListener, err := net.Listen("tcp", o.DebugAPIAddr)
 		if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package aufs
 
 var (
-	version = "1.0.4" // manually set semantic version number
+	version = "1.0.5" // manually set semantic version number
 	commit  string    // automatically set git commit hash
 
 	Version = func() string {


### PR DESCRIPTION
version:1.0.5  
Add field(fullnode,bootnod) return from debugapi/health.