### PR TITLE
feat(traversal): returns chunk hashes seen at pyramid

### DIFF
--- a/pkg/api/aurora.go
+++ b/pkg/api/aurora.go
@@ -156,15 +156,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.Debugf("Manifest Reference: %s", manifestReference.String())
 
-	pyramid, err := s.traversal.GetPyramid(ctx, manifestReference)
-	if err != nil {
-		logger.Debugf("aurora upload file: get pyramid of file %q: %v", fileName, err)
-		logger.Errorf("aurora upload file: get pyramid of file %q", fileName)
-		jsonhttp.InternalServerError(w, "could not get pyramid")
-		return
-	}
-
-	dataChunks, err := s.traversal.GetChunkHashes(ctx, manifestReference, pyramid)
+	dataChunks, _, err := s.traversal.GetChunkHashes(ctx, manifestReference, nil)
 	if err != nil {
 		logger.Debugf("aurora upload file: get chunk hashes of file %q: %v", fileName, err)
 		logger.Errorf("aurora upload file: get chunk hashes of file %q", fileName)
@@ -329,7 +321,7 @@ func (s *server) auroraDownloadHandler(w http.ResponseWriter, r *http.Request) {
 func (s *server) serveManifestEntry(
 	w http.ResponseWriter,
 	r *http.Request,
-	address boson.Address,
+	_ boson.Address,
 	manifestEntry manifest.Entry,
 	etag bool,
 ) {
@@ -401,7 +393,7 @@ type auroraListResponse struct {
 }
 
 // auroraListHandler
-func (s *server) auroraListHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) auroraListHandler(w http.ResponseWriter, _ *http.Request) {
 	responseList := make([]auroraListResponse, 0)
 	fileListInfo, addressList := s.chunkInfo.GetFileList(s.overlay)
 
@@ -573,7 +565,7 @@ func (s *server) manifestViewHandler(w http.ResponseWriter, r *http.Request) {
 			pathVar += "/"
 		}
 
-		if err := m.IterateNodes(ctx, []byte(pathVar), depth, fn); err != nil {
+		if err := m.IterateDirectories(ctx, []byte(pathVar), depth, fn); err != nil {
 			jsonhttp.InternalServerError(w, err)
 			return
 		}

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -80,15 +80,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pyramid, err := s.traversal.GetPyramid(ctx, reference)
-	if err != nil {
-		logger.Debugf("aurora upload dir: get pyramid err: %v", err)
-		logger.Errorf("aurora upload dir: get pyramid err")
-		jsonhttp.InternalServerError(w, "could not get pyramid")
-		return
-	}
-
-	dataChunks, _ := s.traversal.GetChunkHashes(ctx, reference, pyramid)
+	dataChunks, _, err := s.traversal.GetChunkHashes(ctx, reference, nil)
 	if err != nil {
 		logger.Debugf("aurora upload dir: get chunk hashes err: %v", err)
 		logger.Errorf("aurora upload dir: get chunk hashes err")

--- a/pkg/chunkinfo/chunkinfo_test.go
+++ b/pkg/chunkinfo/chunkinfo_test.go
@@ -187,7 +187,7 @@ func TestHandlerChunkInfoResp(t *testing.T) {
 
 	//resp  b ->a
 	tree, _ := bOverlay.getChunkPyramid(ctx, rootCid)
-	pram, _ := bOverlay.traversal.GetChunkHashes(ctx, rootCid, tree)
+	pram, _, _ := bOverlay.traversal.GetChunkHashes(ctx, rootCid, tree)
 	if err := bOverlay.OnChunkTransferred(boson.NewAddress(pram[0][0]), rootCid, bAddress, boson.ZeroAddress); err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestHandlerPyramid(t *testing.T) {
 	)
 	server := mockChunkInfo(s, targetRecorder, serverAddress)
 	tree, _ := server.getChunkPyramid(ctx, rootCid)
-	pram, _ := server.traversal.GetChunkHashes(ctx, rootCid, tree)
+	pram, _, _ := server.traversal.GetChunkHashes(ctx, rootCid, tree)
 	if err := target.OnChunkTransferred(boson.NewAddress(pram[0][1]), rootCid, targetAddress, boson.ZeroAddress); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunkinfo/chunkinfosource.go
+++ b/pkg/chunkinfo/chunkinfosource.go
@@ -203,7 +203,8 @@ func (cs *chunkInfoSource) GetChunkInfoSource(rootCid boson.Address) (sourceResp
 func (cs *chunkInfoSource) DelChunkInfoSource(rootCid boson.Address) bool {
 	cs.Lock()
 	defer cs.Unlock()
-	if err := cs.storer.Iterate(chunkSourceKeyPrefix+"-"+rootCid.String(), func(k, value []byte) (stop bool, err error) {
+	key := fmt.Sprintf("%s%s", chunkSourceKeyPrefix, rootCid.String())
+	if err := cs.storer.Iterate(key, func(k, value []byte) (stop bool, err error) {
 		key := string(k)
 		if !strings.HasPrefix(key, chunkSourceKeyPrefix) {
 			return true, nil
@@ -217,8 +218,8 @@ func (cs *chunkInfoSource) DelChunkInfoSource(rootCid boson.Address) bool {
 		cs.logger.Errorf("chunk source: del rootCid chunk source error:%w", err)
 		return false
 	}
-
-	if err := cs.storer.Iterate(pyramidKeyPrefix+"-"+rootCid.String(), func(k, value []byte) (stop bool, err error) {
+	key = fmt.Sprintf("%s%s", pyramidKeyPrefix, rootCid.String())
+	if err := cs.storer.Iterate(key, func(k, value []byte) (stop bool, err error) {
 		key := string(k)
 		if !strings.HasPrefix(key, pyramidKeyPrefix) {
 			return true, nil

--- a/pkg/chunkinfo/chunkinfosource.go
+++ b/pkg/chunkinfo/chunkinfosource.go
@@ -166,7 +166,10 @@ func (cs *chunkInfoSource) updatePyramidSource(ctx context.Context, rootCid, sou
 			PyramidSource: overlay,
 			ChunkSource:   make(map[string]*bitvector.BitVector),
 		}
+	} else {
+		cs.presence[rc].PyramidSource = overlay
 	}
+
 	return cs.storer.Put(generateKey(pyramidKeyPrefix, rootCid, sourceOverlay), overlay)
 }
 

--- a/pkg/chunkinfo/chunkinfosource.go
+++ b/pkg/chunkinfo/chunkinfosource.go
@@ -203,7 +203,7 @@ func (cs *chunkInfoSource) GetChunkInfoSource(rootCid boson.Address) (sourceResp
 func (cs *chunkInfoSource) DelChunkInfoSource(rootCid boson.Address) bool {
 	cs.Lock()
 	defer cs.Unlock()
-	if err := cs.storer.Iterate(chunkSourceKeyPrefix, func(k, value []byte) (stop bool, err error) {
+	if err := cs.storer.Iterate(chunkSourceKeyPrefix+"-"+rootCid.String(), func(k, value []byte) (stop bool, err error) {
 		key := string(k)
 		if !strings.HasPrefix(key, chunkSourceKeyPrefix) {
 			return true, nil
@@ -218,7 +218,7 @@ func (cs *chunkInfoSource) DelChunkInfoSource(rootCid boson.Address) bool {
 		return false
 	}
 
-	if err := cs.storer.Iterate(pyramidKeyPrefix, func(k, value []byte) (stop bool, err error) {
+	if err := cs.storer.Iterate(pyramidKeyPrefix+"-"+rootCid.String(), func(k, value []byte) (stop bool, err error) {
 		key := string(k)
 		if !strings.HasPrefix(key, pyramidKeyPrefix) {
 			return true, nil

--- a/pkg/chunkinfo/chunkinfotabneighbor.go
+++ b/pkg/chunkinfo/chunkinfotabneighbor.go
@@ -2,6 +2,7 @@ package chunkinfo
 
 import (
 	"context"
+	"fmt"
 	"github.com/gauss-project/aurorafs/pkg/aurora"
 	"github.com/gauss-project/aurorafs/pkg/bitvector"
 	"github.com/gauss-project/aurorafs/pkg/boson"
@@ -175,7 +176,8 @@ func (cn *chunkInfoTabNeighbor) createChunkInfoResp(rootCid boson.Address, ctn m
 func (ci *ChunkInfo) delPresence(rootCid boson.Address) bool {
 	ci.ct.Lock()
 	defer ci.ct.Unlock()
-	if err := ci.storer.Iterate(keyPrefix+"-"+rootCid.String(), func(k, v []byte) (bool, error) {
+	key := fmt.Sprintf("%s%s", keyPrefix, rootCid.String())
+	if err := ci.storer.Iterate(key, func(k, v []byte) (bool, error) {
 		if !strings.HasPrefix(string(k), keyPrefix) {
 			return true, nil
 		}

--- a/pkg/chunkinfo/chunkinfotabneighbor.go
+++ b/pkg/chunkinfo/chunkinfotabneighbor.go
@@ -106,7 +106,7 @@ func (ci *ChunkInfo) updateNeighborChunkInfo(rootCid, cid boson.Address, overlay
 	return ci.storer.Put(generateKey(keyPrefix, rootCid, overlay), &bitVector{B: vb.Bytes(), Len: vb.Len()})
 }
 
-func (ci *ChunkInfo) initNeighborChunkInfo(rootCid boson.Address) {
+func (ci *ChunkInfo) initNeighborChunkInfo(rootCid, peer boson.Address, cids [][]byte) {
 	ci.ct.Lock()
 	defer ci.ct.Unlock()
 	rc := rootCid.String()
@@ -116,6 +116,12 @@ func (ci *ChunkInfo) initNeighborChunkInfo(rootCid boson.Address) {
 		ci.ct.overlays[rc] = []boson.Address{ci.addr}
 		b, _ := ci.getChunkSize(context.Background(), rootCid)
 		vb, _ := bitvector.New(b)
+		for _, cid := range cids {
+			c := boson.NewAddress(cid)
+			s := ci.cp.getCidStore(rootCid, c)
+			vb.Set(s)
+			ci.UpdateChunkInfoSource(rootCid, peer, c)
+		}
 		ci.ct.presence[rc][over] = vb
 	}
 }

--- a/pkg/chunkinfo/chunkinfotabneighbor.go
+++ b/pkg/chunkinfo/chunkinfotabneighbor.go
@@ -175,7 +175,7 @@ func (cn *chunkInfoTabNeighbor) createChunkInfoResp(rootCid boson.Address, ctn m
 func (ci *ChunkInfo) delPresence(rootCid boson.Address) bool {
 	ci.ct.Lock()
 	defer ci.ct.Unlock()
-	if err := ci.storer.Iterate(keyPrefix, func(k, v []byte) (bool, error) {
+	if err := ci.storer.Iterate(keyPrefix+"-"+rootCid.String(), func(k, v []byte) (bool, error) {
 		if !strings.HasPrefix(string(k), keyPrefix) {
 			return true, nil
 		}

--- a/pkg/chunkinfo/chunkpyramid.go
+++ b/pkg/chunkinfo/chunkpyramid.go
@@ -41,7 +41,7 @@ func (ci *ChunkInfo) initChunkPyramid(ctx context.Context, rootCid boson.Address
 	if err != nil {
 		return err
 	}
-	data, err := ci.traversal.GetChunkHashes(ctx, rootCid, trie)
+	data, _, err := ci.traversal.GetChunkHashes(ctx, rootCid, nil)
 	if err != nil {
 		return err
 	}
@@ -119,14 +119,14 @@ func (ci *ChunkInfo) getChunkSize(cxt context.Context, rootCid boson.Address) (i
 	}
 
 	if ci.cp.pyramid[rootCid.String()] == nil {
-		trie, err := ci.traversal.GetChunkHashes(cxt, rootCid, v)
+		trie, _, err := ci.traversal.GetChunkHashes(cxt, rootCid, nil)
 		if err != nil {
 			return 0, err
 		}
 		ci.updateChunkPyramid(rootCid, trie, v)
 	}
 
-	return len(ci.cp.pyramid[rootCid.String()]), nil
+	return len(ci.cp.pyramid[rootCid.String()]) - 1, nil
 }
 
 func (ci *ChunkInfo) getChunkPyramidHash(cxt context.Context, rootCid boson.Address) (map[string][]byte, error) {

--- a/pkg/chunkinfo/chunkpyramid.go
+++ b/pkg/chunkinfo/chunkpyramid.go
@@ -126,7 +126,7 @@ func (ci *ChunkInfo) getChunkSize(cxt context.Context, rootCid boson.Address) (i
 		ci.updateChunkPyramid(rootCid, trie, v)
 	}
 
-	return len(ci.cp.pyramid[rootCid.String()]) - 1, nil
+	return len(ci.cp.pyramid[rootCid.String()]), nil
 }
 
 func (ci *ChunkInfo) getChunkPyramidHash(cxt context.Context, rootCid boson.Address) (map[string][]byte, error) {

--- a/pkg/chunkinfo/message.go
+++ b/pkg/chunkinfo/message.go
@@ -166,7 +166,7 @@ func (ci *ChunkInfo) sendPyramid(ctx context.Context, address boson.Address, str
 			if err = ci.onChunkPyramidResp(ctx, nil, boson.NewAddress(req.RootCid), address, chunkResps); err != nil {
 				return nil, err
 			}
-			if err = ci.UpdatePyramidSource(ctx, boson.NewAddress(req.GetRootCid()), address); err != nil {
+			if err = ci.UpdatePyramidSource(ctx, boson.NewAddress(req.RootCid), address); err != nil {
 				return nil, err
 			}
 			return chunkResps, nil

--- a/pkg/chunkinfo/message.go
+++ b/pkg/chunkinfo/message.go
@@ -163,7 +163,7 @@ func (ci *ChunkInfo) sendPyramid(ctx context.Context, address boson.Address, str
 			return nil, fmt.Errorf("[pyramid info] read message: %w", err)
 		}
 		if resp.Ok {
-			if err = ci.onChunkPyramidResp(ctx, nil, boson.NewAddress(req.RootCid), chunkResps); err != nil {
+			if err = ci.onChunkPyramidResp(ctx, nil, boson.NewAddress(req.RootCid), address, chunkResps); err != nil {
 				return nil, err
 			}
 			if err = ci.UpdatePyramidSource(ctx, boson.NewAddress(req.GetRootCid()), address); err != nil {
@@ -294,7 +294,7 @@ func (ci *ChunkInfo) onChunkPyramidHashReq(ctx context.Context, authInfo []byte,
 }
 
 // onChunkPyramidResp
-func (ci *ChunkInfo) onChunkPyramidResp(ctx context.Context, authInfo []byte, rootCid boson.Address, resps []pb.ChunkPyramidResp) error {
+func (ci *ChunkInfo) onChunkPyramidResp(ctx context.Context, authInfo []byte, rootCid, peer boson.Address, resps []pb.ChunkPyramidResp) error {
 	_, ok := ci.cp.pyramid[rootCid.String()]
 	if ok {
 		return nil
@@ -305,13 +305,13 @@ func (ci *ChunkInfo) onChunkPyramidResp(ctx context.Context, authInfo []byte, ro
 		pyramid[boson.NewAddress(resp.Hash).String()] = resp.Chunk
 	}
 
-	v, err := ci.traversal.GetChunkHashes(ctx, rootCid, pyramid)
+	v, cids, err := ci.traversal.GetChunkHashes(ctx, rootCid, pyramid)
 	if err != nil {
 		ci.logger.Errorf("chunk pyramid: check pyramid error")
 		return err
 	}
 	ci.updateChunkPyramid(rootCid, v, pyramid)
-	ci.initNeighborChunkInfo(rootCid)
+	ci.initNeighborChunkInfo(rootCid, peer, cids)
 	return nil
 }
 

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -21,14 +21,14 @@ type Joiner interface {
 	// Size returns the span of the hash trie represented by the joiner's root hash.
 	Size() int64
 
+	// GetRootData returns root chunk of the given reference.
 	GetRootData() []byte
-	// GetDataChunks order by the file data chunks of reference.
+	// GetDataChunks returns saved data chunk when iteration has ended.
 	GetDataChunks() [][]byte
-	// SetSaveDataChunks
+	// SetSaveDataChunks allows to obtain all chunks lying at bottom.
 	SetSaveDataChunks()
-
-	// SetSaveIntChunks
-	SetSaveIntChunks(data map[string][]byte)
+	// SetSaveEdgeChunks allows to obtain all chunks that not belongs to data.
+	SetSaveEdgeChunks(map[string][]byte)
 }
 
 // Splitter starts a new file splitting job.

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -77,9 +77,9 @@ type Interface interface {
 	HasPrefix(context.Context, string) (bool, error)
 	// Store stores the manifest, returning the resulting address.
 	Store(context.Context, ...StoreSizeFunc) (boson.Address, error)
-	// IterateNodes is used to iterate over directory or file for the
+	// IterateDirectories is used to iterate over directory or file for the
 	// manifest.
-	IterateNodes(context.Context, []byte, int, NodeIterFunc) error
+	IterateDirectories(context.Context, []byte, int, NodeIterFunc) error
 	// IterateAddresses is used to iterate over chunks addresses for
 	// the manifest.
 	IterateAddresses(context.Context, boson.AddressIterFunc) error

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -123,7 +123,7 @@ func (m *mantarayManifest) Store(ctx context.Context, storeSizeFn ...StoreSizeFu
 	return address, nil
 }
 
-func (m *mantarayManifest) IterateNodes(ctx context.Context, path []byte, level int, fn NodeIterFunc) error {
+func (m *mantarayManifest) IterateDirectories(ctx context.Context, path []byte, level int, fn NodeIterFunc) error {
 	reference := boson.NewAddress(m.trie.Reference())
 
 	if boson.ZeroAddress.Equal(reference) {

--- a/pkg/manifest/simple.go
+++ b/pkg/manifest/simple.go
@@ -108,7 +108,7 @@ func (m *simpleManifest) Store(ctx context.Context, storeSizeFn ...StoreSizeFunc
 	return m.reference, nil
 }
 
-func (m *simpleManifest) IterateNodes(ctx context.Context, path []byte, level int, fn NodeIterFunc) error {
+func (m *simpleManifest) IterateDirectories(ctx context.Context, path []byte, level int, fn NodeIterFunc) error {
 	return nil
 }
 


### PR DESCRIPTION
feat(traversal): returns chunk hashes seen at pyramid also fix error check in api, and fix traversal test failure
docs(manifest): rename func IterateNodes
fix(chunkinfo): when the file is smaller than the default chunk size,the bit vector should be recorded.
fix(chunkinfo): batch delete error.
fix(chunkinfo): chunk size error.