### PR TITLE
Feat: user can update some db config in db-driver option

### DIFF
--- a/pkg/shed/driver/driver.go
+++ b/pkg/shed/driver/driver.go
@@ -3,8 +3,7 @@ package driver
 import "io"
 
 type Driver interface {
-	Open(dsn string) (DB, error)
-	Init() Configure
+	Open(dsn, options string) (DB, error)
 }
 
 type DB interface {

--- a/pkg/shed/driver/option.go
+++ b/pkg/shed/driver/option.go
@@ -8,20 +8,26 @@ import (
 type Option interface {
 	Identity() string
 	Value() interface{}
+	Exported() bool
 }
 
 type Configure interface {
-	Options(opts ...Option)
+	Options(opts ...Option) (exported map[string]struct{})
 }
 
 type OptionValue struct {
-	key   string
-	typ   reflect.Type
-	value interface{}
+	key    string
+	typ    reflect.Type
+	value  interface{}
+	export bool
 }
 
-func NewOption(key string, initial interface{}) *OptionValue {
-	return &OptionValue{key: key, typ: reflect.TypeOf(initial)}
+func NewOption(key string, initial interface{}, export bool) *OptionValue {
+	return &OptionValue{
+		key:    key,
+		typ:    reflect.TypeOf(initial),
+		export: export,
+	}
 }
 
 func (ov *OptionValue) Set(v interface{}) {
@@ -82,4 +88,8 @@ func (ov *OptionValue) Identity() string {
 
 func (ov *OptionValue) Value() interface{} {
 	return ov.value
+}
+
+func (ov *OptionValue) Exported() bool {
+	return ov.export
 }

--- a/pkg/shed/leveldb/options.go
+++ b/pkg/shed/leveldb/options.go
@@ -6,10 +6,7 @@ import (
 )
 
 const (
-	optionBlockSize              = "blockSize"
 	optionBlockCacheCapacity     = "blockCacheCapacity"
-	optionCompactionTableSize    = "compactionTableSize"
-	optionCompactionTotalSize    = "compactionTotalSize"
 	optionOpenFilesCacheCapacity = "openFilesCacheCapacity"
 	optionWriteBuffer            = "writeBuffer"
 	optionDisableSeeksCompaction = "disableSeeksCompaction"
@@ -20,14 +17,8 @@ type Configuration opt.Options
 func (c *Configuration) Options(opts ...driver.Option) {
 	for _, o := range opts {
 		switch o.Identity() {
-		case optionBlockSize:
-			c.BlockSize = o.Value().(int)
 		case optionBlockCacheCapacity:
 			c.BlockCacheCapacity = o.Value().(int)
-		case optionCompactionTableSize:
-			c.CompactionTableSize = o.Value().(int)
-		case optionCompactionTotalSize:
-			c.CompactionTotalSize = o.Value().(int)
 		case optionOpenFilesCacheCapacity:
 			c.OpenFilesCacheCapacity = o.Value().(int)
 		case optionDisableSeeksCompaction:
@@ -36,27 +27,9 @@ func (c *Configuration) Options(opts ...driver.Option) {
 	}
 }
 
-func (c *Configuration) SetBlockSize(n int) driver.Option {
-	o := driver.NewOption(optionBlockSize, int(0))
-	o.Set(n)
-	return o
-}
-
 // SetBlockCacheCapacity defines the block cache capacity.
 func (c *Configuration) SetBlockCacheCapacity(n int) driver.Option {
 	o := driver.NewOption(optionBlockCacheCapacity, int(0))
-	o.Set(n)
-	return o
-}
-
-func (c *Configuration) SetCompactionTableSize(n int) driver.Option {
-	o := driver.NewOption(optionCompactionTableSize, int(0))
-	o.Set(n)
-	return o
-}
-
-func (c *Configuration) SetCompactionTotalSize(n int) driver.Option {
-	o := driver.NewOption(optionCompactionTotalSize, int(0))
 	o.Set(n)
 	return o
 }

--- a/pkg/shed/leveldb/options.go
+++ b/pkg/shed/leveldb/options.go
@@ -6,30 +6,40 @@ import (
 )
 
 const (
-	optionBlockCacheCapacity     = "blockCacheCapacity"
-	optionOpenFilesCacheCapacity = "openFilesCacheCapacity"
-	optionWriteBuffer            = "writeBuffer"
-	optionDisableSeeksCompaction = "disableSeeksCompaction"
+	optionBlockCacheCapacity     = "BlockCacheCapacity"
+	optionOpenFilesCacheCapacity = "OpenFilesCacheCapacity"
+	optionWriteBuffer            = "WriteBuffer"
+	optionDisableSeeksCompaction = "DisableSeeksCompaction"
 )
 
 type Configuration opt.Options
 
-func (c *Configuration) Options(opts ...driver.Option) {
+func (c *Configuration) Options(opts ...driver.Option) map[string]struct{} {
+	exported := make(map[string]struct{})
+
 	for _, o := range opts {
 		switch o.Identity() {
 		case optionBlockCacheCapacity:
 			c.BlockCacheCapacity = o.Value().(int)
 		case optionOpenFilesCacheCapacity:
 			c.OpenFilesCacheCapacity = o.Value().(int)
+		case optionWriteBuffer:
+			c.WriteBuffer = o.Value().(int)
 		case optionDisableSeeksCompaction:
 			c.DisableSeeksCompaction = o.Value().(bool)
 		}
+
+		if o.Exported() {
+			exported[o.Identity()] = struct{}{}
+		}
 	}
+
+	return exported
 }
 
 // SetBlockCacheCapacity defines the block cache capacity.
 func (c *Configuration) SetBlockCacheCapacity(n int) driver.Option {
-	o := driver.NewOption(optionBlockCacheCapacity, int(0))
+	o := driver.NewOption(optionBlockCacheCapacity, int(0), true)
 	o.Set(n)
 	return o
 }
@@ -37,21 +47,21 @@ func (c *Configuration) SetBlockCacheCapacity(n int) driver.Option {
 // SetOpenFilesCacheCapacity defines the upper bound of open files that the
 // localstore should maintain at any point of time.
 func (c *Configuration) SetOpenFilesCacheCapacity(n int) driver.Option {
-	o := driver.NewOption(optionOpenFilesCacheCapacity, int(0))
+	o := driver.NewOption(optionOpenFilesCacheCapacity, int(0), true)
 	o.Set(n)
 	return o
 }
 
 // SetWriteBuffer defines the size of writer buffer.
 func (c *Configuration) SetWriteBuffer(n int) driver.Option {
-	o := driver.NewOption(optionWriteBuffer, int(0))
+	o := driver.NewOption(optionWriteBuffer, int(0), true)
 	o.Set(n)
 	return o
 }
 
 // SetDisableSeeksCompaction toggles the seek driven compactions feature on leveldb.
 func (c *Configuration) SetDisableSeeksCompaction(b bool) driver.Option {
-	o := driver.NewOption(optionDisableSeeksCompaction, false)
+	o := driver.NewOption(optionDisableSeeksCompaction, false, true)
 	o.Set(b)
 	return o
 }

--- a/pkg/shed/wiredtiger/wt.go
+++ b/pkg/shed/wiredtiger/wt.go
@@ -30,8 +30,8 @@ func init() {
 }
 
 type DB struct {
+	config  Configuration
 	conn    *C.WT_CONNECTION
-	config  *Configuration
 	pool    *sessionPool
 	closing chan struct{}
 }

--- a/pkg/statestore/leveldb/leveldb.go
+++ b/pkg/statestore/leveldb/leveldb.go
@@ -24,7 +24,7 @@ type store struct {
 }
 
 func NewInMemoryStateStore(l logging.Logger) (storage.StateStorer, error) {
-	ldb, err := leveldbDriver.Open("")
+	ldb, err := leveldbDriver.Open("", "")
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func NewInMemoryStateStore(l logging.Logger) (storage.StateStorer, error) {
 
 // NewStateStore creates a new persistent state storage.
 func NewStateStore(path string, l logging.Logger) (storage.StateStorer, error) {
-	db, err := leveldbDriver.Open(path)
+	db, err := leveldbDriver.Open(path, "")
 	if err != nil {
 		if !ldberr.IsCorrupted(err) {
 			return nil, err


### PR DESCRIPTION
now, `db-driver` option syntax update to `{driver}[:{config-json}]`

like `db-driver: 'wiredtiger:{"cache_size": "1GB"}'`

all support config as below:

```
wt:
  - cache_size
leveldb:
  - BlockCacheCapacity
  - WriteBufferSize
  - OpenFilesLimit
  - DisableSeeksCompaction
```