### PR TITLE
Fix: gc keep batchMu lock, prevent get lock again when call getPyramid in outside

### DIFF
--- a/pkg/api/aurora.go
+++ b/pkg/api/aurora.go
@@ -360,7 +360,7 @@ func (s *server) downloadHandler(w http.ResponseWriter, r *http.Request, referen
 		r = r.WithContext(sctx.SetTargets(r.Context(), targets))
 	}
 
-	reader, l, err := joiner.New(r.Context(), s.storer, reference)
+	reader, l, err := joiner.New(r.Context(), s.storer, storage.ModeGetRequest, reference)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			logger.Debugf("api download: not found %s: %v", reference, err)

--- a/pkg/api/aurora.go
+++ b/pkg/api/aurora.go
@@ -228,7 +228,7 @@ func (s *server) auroraDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r = r.WithContext(sctx.SetRootCID(r.Context(), address))
+	r = r.WithContext(sctx.SetRootHash(r.Context(), address))
 	if !s.chunkInfo.Init(r.Context(), nil, address) {
 		logger.Debugf("aurora download: chunkInfo init %s: %v", nameOrHex, err)
 		jsonhttp.NotFound(w, nil)

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -339,22 +339,7 @@ func (s *server) auroraDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// MUST request local db
-	r = r.WithContext(sctx.SetRootCID(sctx.SetLocalGet(r.Context()), hash))
-
-	// There is no direct return success.
-	_, err = s.storer.Get(r.Context(), storage.ModeGetRequest, hash)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			jsonhttp.NotFound(w, nil)
-			return
-		}
-
-		s.logger.Debugf("aurora delete: check %s exists: %w", hash, err)
-		s.logger.Errorf("aurora delete: check %s exists", hash)
-		jsonhttp.InternalServerError(w, err)
-		return
-	}
+	r = r.WithContext(sctx.SetRootCID(r.Context(), hash))
 
 	del := func() {
 		pyramid := s.chunkInfo.GetChunkPyramid(hash)

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -339,7 +339,7 @@ func (s *server) auroraDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r = r.WithContext(sctx.SetRootCID(r.Context(), hash))
+	r = r.WithContext(sctx.SetRootHash(r.Context(), hash))
 
 	del := func() {
 		pyramid := s.chunkInfo.GetChunkPyramid(hash)

--- a/pkg/file/addresses/addresses_getter_test.go
+++ b/pkg/file/addresses/addresses_getter_test.go
@@ -58,7 +58,7 @@ func TestAddressesGetterIterateChunkAddresses(t *testing.T) {
 
 	addressesGetter := addresses.NewGetter(store, addressIterFunc)
 
-	j, _, err := joiner.New(ctx, addressesGetter, rootChunk.Address())
+	j, _, err := joiner.New(ctx, addressesGetter, storage.ModeGetRequest, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -54,7 +54,7 @@ func testSplitThenJoin(t *testing.T) {
 	}
 
 	// then join
-	r, l, err := joiner.New(ctx, store, resultAddress)
+	r, l, err := joiner.New(ctx, store, storage.ModeGetRequest, resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestJoiner_ErrReferenceLength(t *testing.T) {
 	store := mock.NewStorer()
-	_, _, err := joiner.New(context.Background(), store, boson.ZeroAddress)
+	_, _, err := joiner.New(context.Background(), store, storage.ModeGetLookup, boson.ZeroAddress)
 
 	if !errors.Is(err, storage.ErrReferenceLength) {
 		t.Fatalf("expected ErrReferenceLength %x but got %v", boson.ZeroAddress, err)
@@ -55,7 +55,7 @@ func TestJoinerSingleChunk(t *testing.T) {
 	}
 
 	// read back data and compare
-	joinReader, l, err := joiner.New(ctx, store, mockAddr)
+	joinReader, l, err := joiner.New(ctx, store, storage.ModeGetLookup, mockAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestJoinerDecryptingStore_NormalChunk(t *testing.T) {
 	}
 
 	// read back data and compare
-	joinReader, l, err := joiner.New(ctx, store, mockAddr)
+	joinReader, l, err := joiner.New(ctx, store, storage.ModeGetLookup, mockAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestJoinerWithReference(t *testing.T) {
 	}
 
 	// read back data and compare
-	joinReader, l, err := joiner.New(ctx, store, rootChunk.Address())
+	joinReader, l, err := joiner.New(ctx, store, storage.ModeGetLookup, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestJoinerMalformed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	joinReader, _, err := joiner.New(ctx, store, rootChunk.Address())
+	joinReader, _, err := joiner.New(ctx, store, storage.ModeGetLookup, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestEncryptDecrypt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			reader, l, err := joiner.New(context.Background(), store, resultAddress)
+			reader, l, err := joiner.New(context.Background(), store, storage.ModeGetLookup, resultAddress)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -322,7 +322,7 @@ func TestSeek(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			j, _, err := joiner.New(ctx, store, addr)
+			j, _, err := joiner.New(ctx, store, storage.ModeGetLookup, addr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -600,7 +600,7 @@ func TestPrefetch(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			j, _, err := joiner.New(ctx, store, addr)
+			j, _, err := joiner.New(ctx, store, storage.ModeGetLookup, addr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -647,7 +647,7 @@ func TestJoinerReadAt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	j, _, err := joiner.New(ctx, store, rootChunk.Address())
+	j, _, err := joiner.New(ctx, store, storage.ModeGetLookup, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -692,7 +692,7 @@ func TestJoinerOneLevel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	j, _, err := joiner.New(ctx, store, rootChunk.Address())
+	j, _, err := joiner.New(ctx, store, storage.ModeGetLookup, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -784,7 +784,7 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	j, _, err := joiner.New(ctx, store, rootChunk.Address())
+	j, _, err := joiner.New(ctx, store, storage.ModeGetLookup, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -838,7 +838,7 @@ func TestJoinerIterateChunkAddresses(t *testing.T) {
 
 	createdAddresses := []boson.Address{rootChunk.Address(), firstAddress, secondAddress}
 
-	j, _, err := joiner.New(ctx, store, rootChunk.Address())
+	j, _, err := joiner.New(ctx, store, storage.ModeGetLookup, rootChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/loadsave/loadsave.go
+++ b/pkg/file/loadsave/loadsave.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+
 	"github.com/gauss-project/aurorafs/pkg/boson"
 	"github.com/gauss-project/aurorafs/pkg/file"
 	"github.com/gauss-project/aurorafs/pkg/file/joiner"
@@ -45,7 +46,7 @@ func NewReadonly(storer PutGetter) file.LoadSaver {
 }
 
 func (ls *loadSave) Load(ctx context.Context, ref []byte) ([]byte, error) {
-	j, _, err := joiner.New(ctx, ls.storer, boson.NewAddress(ref))
+	j, _, err := joiner.New(ctx, ls.storer, storage.ModeGetRequest, boson.NewAddress(ref))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -404,7 +404,7 @@ func TestDB_gcSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 	count := 100
 
 	for i := 0; i < count; i++ {
@@ -424,7 +424,7 @@ func TestDB_gcSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 	defer db.Close()
 
 	t.Run("gc index size", newIndexGCSizeTest(db))

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -245,7 +245,7 @@ func TestGCAfterPin(t *testing.T) {
 	// upload random chunks
 	reference, chunks, addGc := addRandomFile(t, chunkCount, db, ci, false)
 
-	ctx := sctx.SetRootCID(context.Background(), reference)
+	ctx := sctx.SetRootHash(context.Background(), reference)
 	for _, chunk := range chunks {
 		err := db.Set(ctx, storage.ModeSetPin, chunk)
 		if err != nil {
@@ -286,7 +286,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 	for i := 0; i < int(db.capacity)-1; i++ {
 		ch := generateTestRandomChunk()
 
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -306,7 +306,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 	// request the latest put chunk
 	// to prioritize it in the gc index
 	// not to be collected
-	ctx := sctx.SetRootCID(context.Background(), addrs[0])
+	ctx := sctx.SetRootHash(context.Background(), addrs[0])
 	_, err := db.Get(ctx, storage.ModeGetRequest, addrs[0])
 	if err != nil {
 		t.Fatal(err)
@@ -326,7 +326,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 	// put request another chunk to trigger
 	// garbage collection
 	ch := generateTestRandomChunk()
-	ctx = sctx.SetRootCID(context.Background(), ch.Address())
+	ctx = sctx.SetRootHash(context.Background(), ch.Address())
 	_, err = db.Put(ctx, storage.ModePutRequest, ch)
 	if err != nil {
 		t.Fatal(err)
@@ -410,7 +410,7 @@ func TestDB_gcSize(t *testing.T) {
 	for i := 0; i < count; i++ {
 		ch := generateTestRandomChunk()
 
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -503,7 +503,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 	// upload random chunks above cache capacity to see if chunks are still pinned
 	for i := 0; i < 20; i++ {
 		ch := generateTestRandomChunk()
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -516,7 +516,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 	}
 	for i := 0; i < 20; i++ {
 		ch := generateTestRandomChunk()
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -524,7 +524,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 	}
 	for i := 0; i < 20; i++ {
 		ch := generateTestRandomChunk()
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -538,7 +538,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 		outItem := shed.Item{
 			Address: addr.Bytes(),
 		}
-		ctx := sctx.SetRootCID(context.Background(), addr)
+		ctx := sctx.SetRootHash(context.Background(), addr)
 		gotChunk, err := db.Get(ctx, storage.ModeGetRequest, boson.NewAddress(outItem.Address))
 		if err != nil {
 			t.Fatal(err)
@@ -639,7 +639,7 @@ func addRandomChunks(t *testing.T, count int, db *DB, pin bool) []boson.Chunk {
 	var chunks []boson.Chunk
 	for i := 0; i < count; i++ {
 		ch := generateTestRandomChunk()
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -807,7 +807,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 			// for all chunks!
 			if i < 2 {
 				mtx.Lock()
-				ctx := sctx.SetRootCID(context.Background(), addrs[i])
+				ctx := sctx.SetRootHash(context.Background(), addrs[i])
 				_, err := db.Get(ctx, storage.ModeGetRequest, addrs[i])
 				mtx.Unlock()
 				if err != nil {
@@ -825,7 +825,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 	// upload random chunks
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
-		ctx := sctx.SetRootCID(context.Background(), ch.Address())
+		ctx := sctx.SetRootHash(context.Background(), ch.Address())
 		_, err := db.Put(ctx, storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -858,15 +858,15 @@ func TestGC_NoEvictDirty(t *testing.T) {
 
 	// the first synced chunk should be removed
 	t.Run("get the first two chunks, third is gone", func(t *testing.T) {
-		_, err := db.Get(sctx.SetRootCID(context.Background(), addrs[0]), storage.ModeGetRequest, addrs[0])
+		_, err := db.Get(sctx.SetRootHash(context.Background(), addrs[0]), storage.ModeGetRequest, addrs[0])
 		if err != nil {
 			t.Error("got error but expected none")
 		}
-		_, err = db.Get(sctx.SetRootCID(context.Background(), addrs[1]), storage.ModeGetRequest, addrs[1])
+		_, err = db.Get(sctx.SetRootHash(context.Background(), addrs[1]), storage.ModeGetRequest, addrs[1])
 		if err != nil {
 			t.Error("got error but expected none")
 		}
-		_, err = db.Get(sctx.SetRootCID(context.Background(), addrs[2]), storage.ModeGetRequest, addrs[2])
+		_, err = db.Get(sctx.SetRootHash(context.Background(), addrs[2]), storage.ModeGetRequest, addrs[2])
 		if !errors.Is(err, storage.ErrNotFound) {
 			t.Errorf("expected err not found but got %v", err)
 		}
@@ -874,7 +874,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 
 	t.Run("only later inserted chunks should be removed", func(t *testing.T) {
 		for i := 2; i < (chunkCount - int(gcTarget)); i++ {
-			_, err := db.Get(sctx.SetRootCID(context.Background(), addrs[i]), storage.ModeGetRequest, addrs[i])
+			_, err := db.Get(sctx.SetRootHash(context.Background(), addrs[i]), storage.ModeGetRequest, addrs[i])
 			if !errors.Is(err, storage.ErrNotFound) {
 				t.Errorf("got error %v, want %v", err, storage.ErrNotFound)
 			}
@@ -883,7 +883,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 
 	// last synced chunk should not be removed
 	t.Run("get most recent synced chunk", func(t *testing.T) {
-		_, err := db.Get(sctx.SetRootCID(context.Background(), addrs[len(addrs)-1]), storage.ModeGetRequest, addrs[len(addrs)-1])
+		_, err := db.Get(sctx.SetRootHash(context.Background(), addrs[len(addrs)-1]), storage.ModeGetRequest, addrs[len(addrs)-1])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -925,7 +925,7 @@ func TestPinAndUnpinChunk(t *testing.T) {
 	// upload random file
 	reference, chunks, addGc := addRandomFile(t, chunkCount, db, ci, false)
 
-	rctx := sctx.SetRootCID(context.Background(), reference)
+	rctx := sctx.SetRootHash(context.Background(), reference)
 	addGc(t)
 
 	// pin upload files for the first time.
@@ -939,7 +939,7 @@ func TestPinAndUnpinChunk(t *testing.T) {
 	chunkCount = 16
 	reference1, chunks1, addGc1 := addRandomFile(t, chunkCount, db, ci, false)
 
-	rctx = sctx.SetRootCID(context.Background(), reference1)
+	rctx = sctx.SetRootHash(context.Background(), reference1)
 	for _, v := range chunks1 {
 		err = db.Set(rctx, storage.ModeSetPin, v)
 		if err != nil {

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -177,7 +177,7 @@ func newTestDB(t testing.TB, o *Options) *DB {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 	t.Cleanup(func() {
 		err := db.Close()
 		if err != nil {

--- a/pkg/localstore/migration_test.go
+++ b/pkg/localstore/migration_test.go
@@ -65,7 +65,7 @@ func TestOneMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 
 	err = db.Close()
 	if err != nil {
@@ -79,7 +79,7 @@ func TestOneMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 
 	schemaName, err := db.schemaName.Get()
 	if err != nil {
@@ -154,7 +154,7 @@ func TestManyMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 
 	err = db.Close()
 	if err != nil {
@@ -168,7 +168,7 @@ func TestManyMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 
 	schemaName, err := db.schemaName.Get()
 	if err != nil {
@@ -236,7 +236,7 @@ func TestMigrationErrorFrom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 
 	err = db.Close()
 	if err != nil {
@@ -298,7 +298,7 @@ func TestMigrationErrorTo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.WithChunkInfo(ci)
+	db.SetChunkInfo(ci)
 
 	err = db.Close()
 	if err != nil {

--- a/pkg/localstore/mode_get.go
+++ b/pkg/localstore/mode_get.go
@@ -43,7 +43,7 @@ func (db *DB) Get(ctx context.Context, mode storage.ModeGet, addr boson.Address)
 		}
 	}()
 
-	out, err := db.get(mode, addr, sctx.GetRootCID(ctx))
+	out, err := db.get(mode, addr, sctx.GetRootHash(ctx))
 	if err != nil {
 		if errors.Is(err, driver.ErrNotFound) {
 			return nil, storage.ErrNotFound

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -34,12 +34,12 @@ import (
 // Put is required to implement storage.Store
 // interface.
 func (db *DB) Put(ctx context.Context, mode storage.ModePut, chs ...boson.Chunk) (exist []bool, err error) {
-	rootAddr := sctx.GetRootCID(ctx)
+	rootHash := sctx.GetRootHash(ctx)
 
 	db.metrics.ModePut.Inc()
 	defer totalTimeMetric(db.metrics.TotalTimePut, time.Now())
 
-	exist, err = db.put(mode, rootAddr, chs...)
+	exist, err = db.put(mode, rootHash, chs...)
 	if err != nil {
 		db.metrics.ModePutFailure.Inc()
 	}

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -165,7 +165,7 @@ func TestModePutUploadPin(t *testing.T) {
 			}
 
 			for _, file := range FileList {
-				ctx := sctx.SetRootCID(context.Background(), file)
+				ctx := sctx.SetRootHash(context.Background(), file)
 
 				_, err := db.Put(ctx, storage.ModePutUploadPin, chunks...)
 				if err != nil {

--- a/pkg/localstore/mode_set.go
+++ b/pkg/localstore/mode_set.go
@@ -33,11 +33,11 @@ import (
 // Set is required to implement chunk.Store
 // interface.
 func (db *DB) Set(ctx context.Context, mode storage.ModeSet, addrs ...boson.Address) (err error) {
-	rootAddr := sctx.GetRootCID(ctx)
+	rootHash := sctx.GetRootHash(ctx)
 
 	db.metrics.ModeSet.Inc()
 	defer totalTimeMetric(db.metrics.TotalTimeSet, time.Now())
-	err = db.set(mode, rootAddr, addrs...)
+	err = db.set(mode, rootHash, addrs...)
 	if err != nil {
 		db.metrics.ModeSetFailure.Inc()
 	}
@@ -61,7 +61,7 @@ func (db *DB) set(mode storage.ModeSet, rootAddr boson.Address, addrs ...boson.A
 	// variables that provide information for operations
 	// to be done after write batch function successfully executes
 	var gcSizeChange int64 // number to add or subtract from gcSize
-	//triggerPullFeed := make(map[uint8]struct{}) // signal pull feed subscriptions to iterate
+	// triggerPullFeed := make(map[uint8]struct{}) // signal pull feed subscriptions to iterate
 
 	switch mode {
 	case storage.ModeSetSync:

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/gauss-project/aurorafs/pkg/boson"
 	"github.com/gauss-project/aurorafs/pkg/chunkinfo"
 	"github.com/gauss-project/aurorafs/pkg/logging"
@@ -22,7 +23,7 @@ type Store struct {
 	logger    logging.Logger
 	chunkInfo chunkinfo.Interface
 	addr      boson.Address
-	//recoveryCallback recovery.Callback // this is the callback to be executed when a chunk fails to be retrieved
+	// recoveryCallback recovery.Callback // this is the callback to be executed when a chunk fails to be retrieved
 }
 
 var (
@@ -44,28 +45,23 @@ func (s *Store) Get(ctx context.Context, mode storage.ModeGet, addr boson.Addres
 	ch, err = s.Storer.Get(ctx, mode, addr)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			if !sctx.GetLocalGet(ctx) {
-				rootCID := sctx.GetRootCID(ctx)
-				if !rootCID.IsZero() {
-					// request from network
-					ch, err = s.retrieval.RetrieveChunk(ctx, rootCID, addr)
-					if err != nil {
-						return nil, ErrRecoveryAttempt
-					}
-
-					return ch, nil
-				}
+			rootCID := sctx.GetRootCID(ctx)
+			if rootCID.IsZero() {
+				return nil, err
 			}
-			return nil, err
+			// request from network
+			ch, err = s.retrieval.RetrieveChunk(ctx, rootCID, addr)
+			if err != nil {
+				return nil, ErrRecoveryAttempt
+			}
+			return ch, nil
 		}
 
 		return nil, fmt.Errorf("netstore get: %w", err)
 	}
-	if !sctx.GetLocalGet(ctx) {
-		rootCID := sctx.GetRootCID(ctx)
-		if !rootCID.IsZero() && !rootCID.Equal(addr) {
-			_ = s.chunkInfo.OnChunkRetrieved(addr, rootCID, s.addr)
-		}
+	rootCID := sctx.GetRootCID(ctx)
+	if !rootCID.IsZero() && !rootCID.Equal(addr) {
+		_ = s.chunkInfo.OnChunkRetrieved(addr, rootCID, s.addr)
 	}
 
 	return ch, nil

--- a/pkg/pinning/pinning.go
+++ b/pkg/pinning/pinning.go
@@ -66,7 +66,7 @@ type Service struct {
 // CreatePin implements Interface.CreatePin method.
 func (s *Service) CreatePin(ctx context.Context, ref boson.Address, traverse bool) error {
 	// iterFn is a pinning iterator function over the leaves of the root.
-	ctx = sctx.SetRootCID(sctx.SetLocalGet(ctx), ref)
+	ctx = sctx.SetRootCID(ctx, ref)
 	iterFn := func(leaf boson.Address) error {
 		switch err := s.pinStorage.Set(ctx, storage.ModeSetPin, leaf); {
 		case errors.Is(err, storage.ErrNotFound):
@@ -96,7 +96,7 @@ func (s *Service) CreatePin(ctx context.Context, ref boson.Address, traverse boo
 // DeletePin implements Interface.DeletePin method.
 func (s *Service) DeletePin(ctx context.Context, ref boson.Address) error {
 	var iterErr error
-	ctx = sctx.SetRootCID(sctx.SetLocalGet(ctx), ref)
+	ctx = sctx.SetRootCID(ctx, ref)
 	// iterFn is a unpinning iterator function over the leaves of the root.
 	iterFn := func(leaf boson.Address) error {
 		err := s.pinStorage.Set(ctx, storage.ModeSetUnpin, leaf)

--- a/pkg/pinning/pinning.go
+++ b/pkg/pinning/pinning.go
@@ -66,7 +66,7 @@ type Service struct {
 // CreatePin implements Interface.CreatePin method.
 func (s *Service) CreatePin(ctx context.Context, ref boson.Address, traverse bool) error {
 	// iterFn is a pinning iterator function over the leaves of the root.
-	ctx = sctx.SetRootCID(ctx, ref)
+	ctx = sctx.SetRootHash(ctx, ref)
 	iterFn := func(leaf boson.Address) error {
 		switch err := s.pinStorage.Set(ctx, storage.ModeSetPin, leaf); {
 		case errors.Is(err, storage.ErrNotFound):
@@ -96,7 +96,7 @@ func (s *Service) CreatePin(ctx context.Context, ref boson.Address, traverse boo
 // DeletePin implements Interface.DeletePin method.
 func (s *Service) DeletePin(ctx context.Context, ref boson.Address) error {
 	var iterErr error
-	ctx = sctx.SetRootCID(ctx, ref)
+	ctx = sctx.SetRootHash(ctx, ref)
 	// iterFn is a unpinning iterator function over the leaves of the root.
 	iterFn := func(leaf boson.Address) error {
 		err := s.pinStorage.Set(ctx, storage.ModeSetUnpin, leaf)

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -323,7 +323,7 @@ func (s *Service) retrieveChunk(ctx context.Context, route aco.Route, rootAddr, 
 	if err != nil {
 		return nil, fmt.Errorf("retrieval: report chunk source: %v", err)
 	}
-	exists, err := s.storer.Put(sctx.SetRootCID(ctx, rootAddr), storage.ModePutRequest, chunk)
+	exists, err := s.storer.Put(sctx.SetRootHash(ctx, rootAddr), storage.ModePutRequest, chunk)
 	if err != nil {
 		return nil, fmt.Errorf("retrieval: storage put cache:%v", err)
 	}

--- a/pkg/sctx/sctx.go
+++ b/pkg/sctx/sctx.go
@@ -23,7 +23,7 @@ type (
 	targetsContextKey struct{}
 	gasPriceKey       struct{}
 	gasLimitKey       struct{}
-	rootCIDKey        struct{}
+	rootHashKey       struct{}
 )
 
 // SetHost sets the http request host in the context
@@ -92,12 +92,12 @@ func GetGasPrice(ctx context.Context) *big.Int {
 	return nil
 }
 
-func SetRootCID(ctx context.Context, rootCID boson.Address) context.Context {
-	return context.WithValue(ctx, rootCIDKey{}, rootCID)
+func SetRootHash(ctx context.Context, rootHash boson.Address) context.Context {
+	return context.WithValue(ctx, rootHashKey{}, rootHash)
 }
 
-func GetRootCID(ctx context.Context) boson.Address {
-	v, ok := ctx.Value(rootCIDKey{}).(boson.Address)
+func GetRootHash(ctx context.Context) boson.Address {
+	v, ok := ctx.Value(rootHashKey{}).(boson.Address)
 	if ok {
 		return v
 	}

--- a/pkg/sctx/sctx.go
+++ b/pkg/sctx/sctx.go
@@ -17,14 +17,13 @@ var (
 )
 
 type (
-	HTTPRequestIDKey  struct{}
-	requestHostKey    struct{}
-	//tagKey            struct{}
+	HTTPRequestIDKey struct{}
+	requestHostKey   struct{}
+	// tagKey            struct{}
 	targetsContextKey struct{}
 	gasPriceKey       struct{}
 	gasLimitKey       struct{}
 	rootCIDKey        struct{}
-	localGetKey       struct{}
 )
 
 // SetHost sets the http request host in the context
@@ -103,13 +102,4 @@ func GetRootCID(ctx context.Context) boson.Address {
 		return v
 	}
 	return boson.ZeroAddress
-}
-
-func SetLocalGet(ctx context.Context) context.Context {
-	return context.WithValue(ctx, localGetKey{}, true)
-}
-
-func GetLocalGet(ctx context.Context) bool {
-	_, ok := ctx.Value(localGetKey{}).(bool)
-	return ok
 }

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -202,9 +202,9 @@ func (s *service) GetChunkHashes(ctx context.Context, addr boson.Address, pyrami
 				return
 			}
 			// here we can put those data into localstore.
-			rctx := sctx.SetRootCID(ctx, addr)
+			rCtx := sctx.SetRootHash(ctx, addr)
 			// first we put root chunk
-			_, err = s.store.Put(rctx, storage.ModePutRequest, boson.NewChunk(addr, pyramid[addr.String()]))
+			_, err = s.store.Put(rCtx, storage.ModePutRequest, boson.NewChunk(addr, pyramid[addr.String()]))
 			if err != nil {
 				return
 			}
@@ -214,7 +214,7 @@ func (s *service) GetChunkHashes(ctx context.Context, addr boson.Address, pyrami
 				if err != nil {
 					return
 				}
-				_, err = s.store.Put(rctx, storage.ModePutRequest, boson.NewChunk(addr, pyramid[k]))
+				_, err = s.store.Put(rCtx, storage.ModePutRequest, boson.NewChunk(addr, pyramid[k]))
 				if err != nil {
 					return
 				}

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -79,7 +79,7 @@ func (s *service) traverseAndProcess(ctx context.Context, addr boson.Address, pr
 // Traverse implements Traverser.Traverse method.
 func (s *service) Traverse(ctx context.Context, addr boson.Address, iterFn boson.AddressIterFunc) error {
 	processBytes := func(ref boson.Address) error {
-		j, _, err := joiner.New(ctx, s.store, ref)
+		j, _, err := joiner.New(ctx, s.store, storage.ModeGetLookup, ref)
 		if err != nil {
 			return fmt.Errorf("traversal: joiner error on %q: %w", ref, err)
 		}
@@ -107,7 +107,7 @@ func dataWithSpan(data []byte, size uint64) []byte {
 // GetPyramid implements Traverser.GetPyramid method.
 func (s *service) GetPyramid(ctx context.Context, addr boson.Address) (pyramid map[string][]byte, err error) {
 	storePyramidHashes := func(ref boson.Address) error {
-		j, span, err := joiner.New(ctx, s.store, ref)
+		j, span, err := joiner.New(ctx, s.store, storage.ModeGetLookup, ref)
 		if err != nil {
 			return fmt.Errorf("traversal: joiner error on %q: %w", ref, err)
 		}
@@ -151,7 +151,7 @@ func (s *service) GetChunkHashes(ctx context.Context, addr boson.Address, pyrami
 		switch nodeType {
 		case int(manifest.File):
 			ref := boson.NewAddress(hash)
-			j, span, err := joiner.New(ctx, store, ref)
+			j, span, err := joiner.New(ctx, store, storage.ModeGetLookup, ref)
 			if err != nil {
 				return fmt.Errorf("traversal: joiner error on %q: %w", ref, err)
 			}


### PR DESCRIPTION
using storage.ModeGetLookup to skip gc update while call traversal function